### PR TITLE
Add seperator " _ " and  removetext "M/V"

### DIFF
--- a/app/src/main/java/com/arn/scrobble/Stuff.kt
+++ b/app/src/main/java/com/arn/scrobble/Stuff.kt
@@ -162,7 +162,7 @@ object Stuff {
     )
 
     private val seperators = arrayOf(// in priority order
-            "—", " ‎– ", "–", " - ", " \\| ", "-", "「", "『", "ー", " • ",
+            "—", " ‎– ", "–", " _ ", " - ", " \\| ", "-", "「", "『", "ー", " • ",
 
             "【", "〖", "〔",
             "】", "〗", "』", "」", "〕",
@@ -232,7 +232,7 @@ object Stuff {
                 .replace(" *\\[[^)]*] *".toRegex(), " ")
 
                 //remove HD info
-                .replace("\\W* HD|HQ|4K|MV|Official Music Video|Music Video|Lyric Video|Official Audio( \\W*)?"
+                .replace("\\W* HD|HQ|4K|MV|M/V|Official Music Video|Music Video|Lyric Video|Official Audio( \\W*)?"
                         .toRegex(RegexOption.IGNORE_CASE)
                         , " ")
 


### PR DESCRIPTION
- Many Youtube videos use ` _ ` as a separator which the parser does not yet understand. This results in raising `Couldn't parse title` error. This commit should fix the issue 
- Also adding "M/V" to the unnecessary tags filter.


