### PR TITLE
Add a space in the Scrobble from mic dialog

### DIFF
--- a/app/src/main/java/com/arn/scrobble/RecFragment.kt
+++ b/app/src/main/java/com/arn/scrobble/RecFragment.kt
@@ -297,8 +297,8 @@ class RecFragment: Fragment(),
         when(statusCode) {
             0 -> {
                 binding.recImg.setImageResource(R.drawable.vd_check_simple)
-                binding.recStatus.text = getString(R.string.state_scrobbled) +
-                        getString(R.string.artist_title, artist, title)
+                binding.recStatus.text =
+                    getString(R.string.state_scrobbled) + ' ' + getString(R.string.artist_title, artist, title)
                 val scrobbleData = ScrobbleData()
                 scrobbleData.artist = artist
                 scrobbleData.album = album


### PR DESCRIPTION
Otherwise it reads "ScrobbledARTIST — Track", e.g: 
![image](https://user-images.githubusercontent.com/1432131/130651836-58bc9c9f-a194-4845-8770-a7772831bdee.png)

Ideally it'd be localised and reversible but this is a quick fix.