### PR TITLE
When ignoring artist meta, check if newly parsed data are empty

### DIFF
--- a/app/src/main/java/com/arn/scrobble/NLService.kt
+++ b/app/src/main/java/com/arn/scrobble/NLService.kt
@@ -658,8 +658,8 @@ class NLService : NotificationListenerService() {
                     val (parsedArtist, parsedTitle) = MetadataUtils.parseArtistTitle(title)
 
                     unparsedScrobbleData = scrobbleData.copy()
-                    scrobbleData.artist = parsedArtist
-                    scrobbleData.track = parsedTitle
+                    if (parsedArtist.isNotEmpty()) scrobbleData.artist = parsedArtist
+                    if (parsedTitle.isNotEmpty()) scrobbleData.track = parsedTitle
                     scrobbleData.albumArtist = ""
                     scrobbleData.album = ""
                 } else if (packageName in browserPackages) {


### PR DESCRIPTION
In some cases the artist field in a notification will be the actual artist's name, and the title will be the actual song title. Be optimistic and use the originally parsed data if the new are empty. Take for example listening to a song in NewPipe for which the upload was by a YouTube auto-generated channel for the artist. The notification title field will only contain the song title (without this change this results in a parse error), and the notification artist field will be the channel name, which is the actual artist's name.