### PR TITLE
Add OuterTune as YouTube Music alternative

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/arn/scrobble/utils/Stuff.kt
+++ b/composeApp/src/commonMain/kotlin/com/arn/scrobble/utils/Stuff.kt
@@ -223,6 +223,7 @@ object Stuff {
         PACKAGE_YOUTUBE_MUSIC,
         "com.vanced.android.apps.youtube.music",
         "app.revanced.android.apps.youtube.music",
+        "com.dd3boh.outertune",
     )
 
     val BLOCKED_MEDIA_SESSION_TAGS = mapOf(


### PR DESCRIPTION
This adds [OuterTune](https://github.com/OuterTune/OuterTune), a music player that supports both local files + YouTube Music as a backend, to the list of apps under `IGNORE_ARTIST_META_WITH_FALLBACK`. Since it uses YTM as a backend, it suffers from the same title issues as the other apps under `IGNORE_ARTIST_META_WITH_FALLBACK`. I see it as being adjacent to the vanced/revanced YTM clients.