### PR TITLE
Ignore SomaFM station labels exposed as browser album metadata

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/arn/scrobble/media/MetadataTransforms.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/arn/scrobble/media/MetadataTransforms.android.kt
@@ -116,6 +116,13 @@ actual fun transformMediaMetadata(
          */
     }
 
+    if (trackInfo.appId in BROWSER_PACKAGES_WITH_WEB_MEDIA_SESSION && album.isSomaFmStationAlbum()) {
+        album = ""
+        if (albumArtist.isSomaFmStationAlbum()) {
+            albumArtist = ""
+        }
+    }
+
 //    if (trackInfo.appId in Stuff.IGNORE_ARTIST_META)
 //        trackInfo.artist = trackInfo.artist.substringBeforeLast(" - Topic")
 
@@ -142,3 +149,21 @@ actual fun transformMediaMetadata(
 }
 
 private const val METADATA_KEY_ADVERTISEMENT = "android.media.metadata.ADVERTISEMENT"
+
+private val BROWSER_PACKAGES_WITH_WEB_MEDIA_SESSION = setOf(
+    "com.brave.browser",
+    "com.brave.browser_beta",
+    "com.brave.browser_nightly",
+    "com.android.chrome",
+    "com.chrome.beta",
+    "com.chrome.dev",
+    "com.chrome.canary",
+    "org.mozilla.firefox",
+    "org.mozilla.firefox_beta",
+    "org.mozilla.fenix",
+    "org.mozilla.fennec_fdroid",
+)
+
+private val SOMAFM_STATION_ALBUM_PATTERN = Regex("""\s+on\s+SomaFM\s*$""", RegexOption.IGNORE_CASE)
+
+private fun String.isSomaFmStationAlbum() = SOMAFM_STATION_ALBUM_PATTERN.containsMatchIn(this)


### PR DESCRIPTION
## Summary

Fixes a metadata edge case where SomaFM playback through Android browsers can expose the radio station name as the album title.

Example:

- Title: `Give You Everything`
- Artist: `Barrington Levy`
- Reported album: `Heavyweight Reggae on SomaFM`

Pano currently treats the non-empty album field as authoritative, so the existing missing-album lookup path is not able to repair the metadata. This change clears browser-provided SomaFM station labels from the album field so normal metadata repair can run.

## Scope

This is intentionally narrow:

- Only applies to known browser package IDs using web media-session metadata.
- Only clears album values matching the SomaFM station-label pattern: `... on SomaFM`.
- Does not add a settings surface.
- Does not change scrobbling behavior for native music apps.
- Does not change artwork handling.
- Does not add docs, templates, or process files.

## Why

SomaFM’s web player can show richer/correct track metadata in-browser, but Android media metadata exposed by browsers may contain the station label in the album field. That pseudo-album is not useful as release metadata and prevents Pano from resolving the correct album.

## Validation

Tested locally with:

- Android device
- Brave browser
- SomaFM web player
- Track: `Give You Everything` by `Barrington Levy`

Before this change, Pano scrobbled the album as `Heavyweight Reggae on SomaFM`.

After this change, the SomaFM station label is no longer preserved as the album, allowing existing missing-album repair behavior to resolve better metadata.

## Related

Related to #347, but this PR does not implement general per-app metadata rewrite rules. It only filters a known pseudo-album value emitted through browser media-session metadata.